### PR TITLE
linux compile-able version of ncpatcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ include_directories(${RAPIDJSON_INCLUDE_DIR})
 include("${CMAKE_SOURCE_DIR}/vendor/thread-pool.cmake")
 include_directories(${THREADPOOL_INCLUDE_DIR})
 
+#add pthread to the libraries because that's required apparently
+add_link_options(-pthread)
+
 # Find the source files
 file(GLOB_RECURSE SOURCES "source/*.cpp")
 

--- a/source/config/json.hpp
+++ b/source/config/json.hpp
@@ -14,6 +14,11 @@
 #pragma GCC diagnostic pop
 #endif
 
+//this line right here allows for linux support, by replacing fopen_s with fopen.
+#ifdef __unix
+#define fopen_s(pFile,filename,mode) ((*(pFile))=fopen((filename),(mode)))==NULL
+#endif
+
 class JsonMember
 {
 public:


### PR DESCRIPTION
as someone who does a lot of stuff on linux rather than windows i tried to compile ncpatcher on linux, i noticed then that ncpatcher uses fopen_s, thought i should just adapt very slightly the source to allow for compiling on linux, not sure if that has any consequence though so feel free to check i guess